### PR TITLE
Add support for directly citing an archive.org page

### DIFF
--- a/src/lib/static.ts
+++ b/src/lib/static.ts
@@ -130,7 +130,7 @@ export class QWikiCite {
    * @returns the escaped string
    */
   public static esc(s: string): string {
-    return s.replace(/[|]/g, '&#124;').replace(/[{]/g, '&#123;').replace(/[}]/g, '&#125;').replace(/[=]/g, '&#61;')
+    return s.replace(/[|]/g, '&#124;').replace(/[{]/g, '&#123;').replace(/[}]/g, '&#125;')
   }
 
   /**

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -5,7 +5,7 @@ import Browser from 'webextension-polyfill';
 /**
  * Lightly modified from https://github.com/BetaHuhn/metadata-scraper/blob/master/src/index.ts
  */
-const getMetaData = function (inputOptions: Partial<Options> = {}) {
+const getMetaData = function (url: string, inputOptions: Partial<Options> = {}) {
 
     const defaultOptions = {
         maxRedirects: 5,
@@ -58,8 +58,7 @@ const getMetaData = function (inputOptions: Partial<Options> = {}) {
 
         return undefined
     }
-
-    const url = window.location.href;
+    
     const options = Object.assign({}, defaultOptions, inputOptions)
 
     const rules: Record<string, RuleSet> = { ...metaDataRules }
@@ -85,7 +84,7 @@ const getMetaData = function (inputOptions: Partial<Options> = {}) {
     return metadata
 }
 
-Browser.runtime.onMessage.addListener(() => {
+Browser.runtime.onMessage.addListener((message) => {
     console.debug('QWiki-Cite asked for the details of this page, beginning a scrape');
-    return Promise.resolve(getMetaData());
+    return Promise.resolve(getMetaData(message.url || window.location.href));
 });

--- a/test/lib/static.test.ts
+++ b/test/lib/static.test.ts
@@ -8,10 +8,6 @@ describe("string escape", () => {
         expect(QWikiCite.esc('Test Page | Site')).to.equal("Test Page &#124; Site");
     })
 
-    test("replaces equals", () => {
-        expect(QWikiCite.esc('Test Page = Site')).to.equal("Test Page &#61; Site");
-    })
-
     test("replaces curly brackets", () => {
         expect(QWikiCite.esc('Test Page {{ why }} Site')).to.equal("Test Page &#123;&#123; why &#125;&#125; Site");
     })


### PR DESCRIPTION
If you happen to already be looking at an archive.org page, we want to capture that as the `archive-url` parameter so we can skip the lookup on the archive.org API.