### PR TITLE
Add in-browser tests for parsing behaviour

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "devDependencies": {
     "@parcel/config-webextension": "^2.10.3",
+    "@playwright/test": "^1.40.1",
     "@types/chai": "^4.3.11",
     "@types/mocha": "^10.0.6",
     "@types/moment": "^2.13.0",
@@ -29,7 +30,7 @@
     "url": "^0.11.0"
   },
   "scripts": {
-    "test": "ts-mocha ./test/**/*",
+    "test": "yarn build && yarn playwright install && ts-mocha --timeout 30000 ./test/**/*",
     "build": "rm -rf dist .cache .parcel-cache && parcel build --no-cache src/manifest.json",
     "watch": "parcel watch --host localhost src/manifest.json",
     "bundle": "yarn test && yarn build && zip -j qwiki-cite-$npm_package_version.zip ./dist/*"

--- a/src/lib/static.ts
+++ b/src/lib/static.ts
@@ -72,20 +72,15 @@ export class QWikiCite {
       if (parsedDate != null) {
         citationTemplate.date = parsedDate;
       }
-
-      // parse the newspaper page number from the title if possible
-      const pageNumber = [...citationTemplate.title.matchAll(/.*Page (\d+)[^\d]*/gi)];
-      if (pageNumber.length && pageNumber[0].length) {
-        citationTemplate.page = pageNumber[0][pageNumber[0].length-1];
-      }
     }
+    if (metadata.pageNumber != null) citationTemplate.page = metadata.pageNumber as string;
     if (metadata.language != null) citationTemplate.language = metadata.language
     if (metadata.provider != null) citationTemplate.website = metadata.provider
 
     if (metadata.publisher != null) citationTemplate.publisher = (metadata.publisher as string).trim()
     if (metadata.isbn != null) citationTemplate.isbn = (metadata.isbn as string).trim()
     if (metadata.location != null) citationTemplate.location = (metadata.location as string).trim()
-    if (metadata.type != null) citationTemplate.type = (metadata.type as string).trim()
+    if (metadata.type == 'book') citationTemplate.type = (metadata.type as string).trim()
 
     const parseAuthor = (input: string): [string?, string?] => {
       // try and break the name into components
@@ -106,6 +101,8 @@ export class QWikiCite {
         'journalist',
         'reporter',
         'http',
+        'national',
+        'library',
       ];
 
       websiteName?.split(' ').map((s) => s.toLowerCase()).forEach((s) => suspiciousStrings.push(s));

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -11,7 +11,11 @@
     "content_scripts": [
       {
         "matches": ["<all_urls>"],
-        "js": ["parser.ts"]
+        "js": ["page-script.ts"]
+      },
+      {
+        "matches": ["http://cloventt.net/"],
+        "js": ["parsers.ts"]
       }
     ],
     "icons": {

--- a/src/page-script.ts
+++ b/src/page-script.ts
@@ -1,0 +1,16 @@
+import Browser from 'webextension-polyfill';
+import { scrapePage, parseWorldCat, getGenericMetadata } from './parsers';
+
+declare global {
+    interface Window {
+        parseWorldCat: Function;
+        getGenericMetadata: Function;
+    }
+}
+
+window.parseWorldCat = parseWorldCat;
+window.getGenericMetadata = getGenericMetadata;
+
+Browser.runtime.onMessage.addListener(scrapePage);
+
+Browser.runtime.connect();

--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -123,23 +123,23 @@ export const parseWorldCat = function () {
     const bookElement = dataFeed['dataFeedElement'][0];
 
     const metadata: MetaData = {};
-    metadata.title = bookElement.name;
-    metadata.url = bookElement.url;
-    metadata.type = bookElement['@type']?.toLowerCase();
-    metadata.author = bookElement.author?.name;
+    metadata.title = bookElement.name.trim();
+    metadata.url = bookElement.url.trim();
+    metadata.type = bookElement['@type']?.toLowerCase().trim();
+    metadata.author = bookElement.author?.name.trim();
 
     const bookElementExample = bookElement.workExample[0];
     if (bookElementExample != null) {
         metadata.published = bookElementExample.datePublished;
         metadata.isbn = bookElementExample.isbn;
-        metadata.language = bookElementExample.inLanguage;
+        metadata.language = Intl.getCanonicalLocales(bookElementExample.inLanguage)[0];
         metadata.edition = bookElementExample.bookEdition;
     };
 
     const rawPubString = document.querySelectorAll('span[data-testid*="publisher"]')[0].textContent.split(',');
-    metadata.publisher = rawPubString[0];
-    metadata.location = rawPubString[rawPubString.length - 2];
-    metadata.year = rawPubString[rawPubString.length - 1];
+    metadata.publisher = rawPubString[0].trim();
+    metadata.location = rawPubString[rawPubString.length - 2].trim();
+    metadata.year = rawPubString[rawPubString.length - 1].trim();
     return metadata;
 }
 

--- a/test/lib/convert.test.ts
+++ b/test/lib/convert.test.ts
@@ -192,6 +192,15 @@ describe("page scrape metadata conversion", () => {
             },
         },
         {
+            description: 'ignores National Library of New Zealand',
+            input: {
+                author: 'National Library of New Zealand'
+            },
+            expected: {
+                accessDate: '2023-12-25',
+            },
+        },
+        {
             description: 'ignores author role in square brackets',
             input: {
                 author: 'David Palmer [Senior Staff Writer]'
@@ -235,24 +244,12 @@ describe("page scrape metadata conversion", () => {
             },
         },
         {
-            description: 'grabs newspaper page number from title if present (lowercase)',
+            description: 'grabs newspaper page number if present',
             input: {
-                title: 'Hot New Article - page 8 -test',
+                pageNumber: '7',
             },
             expected: {
-                title: 'Hot New Article - page 8 -test',
-                page: '8',
-                accessDate: '2023-12-25',
-            },
-        },
-        {
-            description: 'grabs newspaper page number from title if present (capitalised)',
-            input: {
-                title: 'Hot New Article - Page 18 -test',
-            },
-            expected: {
-                title: 'Hot New Article - Page 18 -test',
-                page: '18',
+                page: '7',
                 accessDate: '2023-12-25',
             },
         },

--- a/test/lib/parser.test.ts
+++ b/test/lib/parser.test.ts
@@ -32,6 +32,24 @@ describe("page scraping works as expected", () => {
         });
     });
 
+    test('on worldcat', async () => {
+        const url = 'https://search.worldcat.org/title/1250610805';
+        await page.goto(url);
+        await page.addScriptTag({ path: './dist/parsers.js' });
+        const scrapeResult = await page.evaluate(`window.scrapePage({url:'${url}'})`);
+        expect(scrapeResult).to.deep.include({
+            author: 'Geoffrey W. Rice',
+            publisher: 'Canterbury University Press',
+            location: 'NZ',  // can't really do much better than this
+            language: 'en',
+            title: 'Black November : the 1918 influenza pandemic in New Zealand',
+            published: '2005',
+            type: 'book',
+            isbn: '9781877257353',
+            url: 'https://search.worldcat.org/title/1250610805',
+        });
+    });
+
     beforeEach(async () => {
         browser = await playwright['firefox'].launch({ headless: true });
         context = await browser.newContext({

--- a/test/lib/parser.test.ts
+++ b/test/lib/parser.test.ts
@@ -50,6 +50,21 @@ describe("page scraping works as expected", () => {
         });
     });
 
+    test('on The Press', async () => {
+        const url = 'https://www.thepress.co.nz/nz-news/350124379/phil-maugers-roving-footpath-crew-completes-2000-repairs';
+        await page.goto(url);
+        await page.addScriptTag({ path: './dist/parsers.js' });
+        const scrapeResult = await page.evaluate(`window.scrapePage({url:'${url}'})`);
+        expect(scrapeResult).to.deep.include({
+            author: 'Tina Law',
+            provider: 'The Press',
+            language: 'en',
+            title: 'Phil Mauger’s roving footpath crew completes 2000 repairs',
+            published: '2024-01-03T16:00:00.000Z',
+            url,
+        });
+    });
+
     beforeEach(async () => {
         browser = await playwright['firefox'].launch({ headless: true });
         context = await browser.newContext({

--- a/test/lib/parser.test.ts
+++ b/test/lib/parser.test.ts
@@ -1,6 +1,7 @@
 import { describe, test } from 'mocha'
 import { expect } from 'chai'
 import * as playwright from '@playwright/test';
+import moment from 'moment';
 
 const TEST_TIMEOUT = 30000;
 
@@ -24,7 +25,9 @@ describe("page scraping works as expected", () => {
             author: 'National Library of New Zealand',
             provider: 'Press',
             language: 'en',
-            title: '\nCouncil seat ‘vote against station’\nPress, 15 February 1985, Page 7\n',
+            title: 'Council seat ‘vote against station’',
+            published: '1985-02-15T00:00:00.000Z',
+            pageNumber: '7',
             url: 'https://paperspast.natlib.govt.nz/newspapers/CHP19850215.2.71',
         });
     });

--- a/test/lib/parser.test.ts
+++ b/test/lib/parser.test.ts
@@ -65,6 +65,21 @@ describe("page scraping works as expected", () => {
         });
     });
 
+    test('on The Wall Street Journal', async () => {
+        const url = 'https://www.wsj.com/us-news/law/trump-asks-supreme-court-to-overturn-his-removal-from-colorado-primary-ballot-3eeaedb0';
+        await page.goto(url);
+        await page.addScriptTag({ path: './dist/parsers.js' });
+        const scrapeResult = await page.evaluate(`window.scrapePage({url:'${url}'})`);
+        expect(scrapeResult).to.deep.include({
+            // author: ['Jan Wolfe', 'Jess Bravin'],  // TODO: use schema.org to determine this accurately
+            // provider: 'The Wall Street Journal', // TODO: use schema.org to determine this accurately
+            language: 'en',
+            title: 'Trump Asks Supreme Court to Overturn His Removal From Colorado Primary Ballot',
+            // published: '2024-01-03T22:10:00.000Z',  // TODO: use schema.org to determine this accurately
+            url,
+        });
+    });
+
     beforeEach(async () => {
         browser = await playwright['firefox'].launch({ headless: true });
         context = await browser.newContext({

--- a/test/lib/parser.test.ts
+++ b/test/lib/parser.test.ts
@@ -1,0 +1,45 @@
+import { describe, test } from 'mocha'
+import { expect } from 'chai'
+import * as playwright from '@playwright/test';
+
+const TEST_TIMEOUT = 30000;
+
+let page: playwright.Page; 
+let browser: playwright.Browser;
+let context: playwright.BrowserContext;
+
+describe("page scraping works as expected", () => {
+
+    /**
+     * These tests run on _real_ web pages to ensure the yarscraper works 
+     * in the way we expect.
+     */
+
+    test('on papers past', async () => {
+        const url = 'https://paperspast.natlib.govt.nz/newspapers/CHP19850215.2.71';
+        await page.goto(url);
+        await page.addScriptTag({ path: './dist/parsers.js' });
+        const scrapeResult = await page.evaluate(`window.scrapePage({url:'${url}'})`);
+        expect(scrapeResult).to.deep.include({
+            author: 'National Library of New Zealand',
+            provider: 'Press',
+            language: 'en',
+            title: '\nCouncil seat ‘vote against station’\nPress, 15 February 1985, Page 7\n',
+            url: 'https://paperspast.natlib.govt.nz/newspapers/CHP19850215.2.71',
+        });
+    });
+
+    beforeEach(async () => {
+        browser = await playwright['firefox'].launch({ headless: true });
+        context = await browser.newContext({
+            bypassCSP: true,
+        });
+        page = await context.newPage();
+    })
+
+    afterEach(async () => {
+        browser.close();
+    });
+
+
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
     ],
     "compilerOptions": {
         "lib": [
-            "dom"
+            "dom",
+            "ES2020.Intl",
         ],
         "target": "ES2022",
         "module": "NodeNext",

--- a/yarn.lock
+++ b/yarn.lock
@@ -940,6 +940,13 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
+"@playwright/test@^1.40.1":
+  version "1.40.1"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.40.1.tgz#9e66322d97b1d74b9f8718bacab15080f24cde65"
+  integrity sha512-EaaawMTOeEItCRvfmkI9v6rBkF1svM8wjl/YPRrg2N2Wmp+4qJYkWtJsbew1szfKKDm6fPLy4YAanBhIlf9dWw==
+  dependencies:
+    playwright "1.40.1"
+
 "@pnpm/config.env-replace@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz#ab29da53df41e8948a00f2433f085f54de8b3a4c"
@@ -2581,6 +2588,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
+fsevents@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
 fsevents@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
@@ -4122,6 +4134,20 @@ pino@8.16.2:
     safe-stable-stringify "^2.3.1"
     sonic-boom "^3.7.0"
     thread-stream "^2.0.0"
+
+playwright-core@1.40.1:
+  version "1.40.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.40.1.tgz#442d15e86866a87d90d07af528e0afabe4c75c05"
+  integrity sha512-+hkOycxPiV534c4HhpfX6yrlawqVUzITRKwHAmYfmsVreltEl6fAZJ3DPfLMOODw0H3s1Itd6MDCWmP1fl/QvQ==
+
+playwright@1.40.1:
+  version "1.40.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.40.1.tgz#a11bf8dca15be5a194851dbbf3df235b9f53d7ae"
+  integrity sha512-2eHI7IioIpQ0bS1Ovg/HszsN/XKNwEG1kbzSDDmADpclKc7CyqkHw7Mg2JCz/bbCxg25QUPcjksoMW7JcIFQmw==
+  dependencies:
+    playwright-core "1.40.1"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 postcss-value-parser@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
These tests should make it easier to add additional parsing behaviours in the future, and also detect when a supported website has changed and is no longer compatible with the parser in some way.